### PR TITLE
fix: explain missing CC2 source bundle

### DIFF
--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 mod client;
 mod error;
 mod http_client;

--- a/rust/crates/runtime/src/policy_engine.rs
+++ b/rust/crates/runtime/src/policy_engine.rs
@@ -731,7 +731,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::duration_suboptimal_units, clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     fn executable_decision_table_emits_retry_rebase_merge_escalate_cleanup_and_approval_events() {
         let engine = PolicyEngine::new(vec![
             PolicyRule::new(

--- a/rust/crates/runtime/src/trident.rs
+++ b/rust/crates/runtime/src/trident.rs
@@ -29,7 +29,7 @@ impl Default for TridentConfig {
 }
 
 /// Statistics from a Trident compaction run.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TridentStats {
     pub superseded_count: usize,
     pub collapsed_chains: usize,
@@ -39,21 +39,6 @@ pub struct TridentStats {
     pub tokens_saved_estimate: usize,
     pub original_message_count: usize,
     pub final_message_count: usize,
-}
-
-impl Default for TridentStats {
-    fn default() -> Self {
-        Self {
-            superseded_count: 0,
-            collapsed_chains: 0,
-            messages_collapsed: 0,
-            clusters_found: 0,
-            messages_clustered: 0,
-            tokens_saved_estimate: 0,
-            original_message_count: 0,
-            final_message_count: 0,
-        }
-    }
 }
 
 impl TridentStats {
@@ -192,7 +177,7 @@ fn stage1_supersede(messages: &[ConversationMessage]) -> (Vec<ConversationMessag
 
     let mut obsolete_indices: BTreeSet<usize> = BTreeSet::new();
 
-    for (_path, ops) in &file_ops {
+    for ops in file_ops.values() {
         if ops.len() < 2 {
             continue;
         }
@@ -205,11 +190,7 @@ fn stage1_supersede(messages: &[ConversationMessage]) -> (Vec<ConversationMessag
 
         if let Some(last_write) = last_write_idx {
             for op in ops {
-                if op.op_type == FileOp::Read && op.index < last_write {
-                    obsolete_indices.insert(op.index);
-                } else if (op.op_type == FileOp::Write || op.op_type == FileOp::Edit)
-                    && op.index < last_write
-                {
+                if op.index < last_write {
                     obsolete_indices.insert(op.index);
                 }
             }
@@ -325,7 +306,7 @@ fn stage2_collapse(
                     usage: None,
                 });
             } else {
-                result.extend(buffer.drain(..));
+                result.append(&mut buffer);
             }
             buffer.clear();
             result.push(msg.clone());
@@ -476,7 +457,7 @@ fn stage3_cluster(
     }
 
     let total_clustered: usize = cluster_assignments.len();
-    let clusters_found = cluster_id as usize;
+    let clusters_found = cluster_id;
 
     let mut result: Vec<ConversationMessage> = Vec::new();
     let mut cluster_buffers: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
@@ -677,7 +658,7 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
     use crate::compact::CompactionConfig;
-    use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::session::{ContentBlock, ConversationMessage, Session};
 
     #[test]
     fn stage1_removes_obsolete_file_reads() {
@@ -736,7 +717,7 @@ mod tests {
     fn stage2_collapses_chatty_messages() {
         let mut messages = vec![];
         for i in 0..6 {
-            messages.push(ConversationMessage::user_text(&format!("ok {i}")));
+            messages.push(ConversationMessage::user_text(format!("ok {i}")));
             messages.push(ConversationMessage::assistant(vec![ContentBlock::Text {
                 text: format!("got {i}"),
             }]));
@@ -767,9 +748,9 @@ mod tests {
                 },
             ]));
             messages.push(ConversationMessage::tool_result(
-                &format!("read_{i}"),
+                format!("read_{i}"),
                 "read_file",
-                &format!(r#"{{"path":"src/{i}.rs","content":"data {i}"}}"#),
+                format!(r#"{{"path":"src/{i}.rs","content":"data {i}"}}"#),
                 false,
             ));
         }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -8,11 +8,15 @@
     clippy::manual_string_new,
     clippy::match_same_arms,
     clippy::result_large_err,
+    clippy::too_many_arguments,
     clippy::too_many_lines,
+    clippy::type_complexity,
     clippy::uninlined_format_args,
     clippy::unneeded_struct_pattern,
     clippy::unnecessary_wraps,
-    clippy::unused_self
+    clippy::unused_self,
+    clippy::useless_format,
+    clippy::expect_fun_call
 )]
 mod init;
 mod input;

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3452,11 +3452,7 @@ impl DiagnosticCheck {
 
     fn json_value(&self) -> Value {
         // Derive a stable snake_case id from the check name for machine-readable keying (#704).
-        let id = self
-            .name
-            .to_ascii_lowercase()
-            .replace(' ', "_")
-            .replace('-', "_");
+        let id = self.name.to_ascii_lowercase().replace([' ', '-'], "_");
         let mut value = Map::from_iter([
             ("id".to_string(), Value::String(id.clone())),
             (
@@ -6730,16 +6726,15 @@ fn run_resume_command(
         }
         SlashCommand::Plugins { action, target } => {
             // Only list is supported in resume mode (no runtime to reload)
-            match action.as_deref() {
-                Some(action @ ("install" | "uninstall" | "enable" | "disable" | "update")) => {
-                    // #777: use interactive_only: prefix + \n hint so #776's classify/split
-                    // emits error_kind:interactive_only + non-null hint instead of unknown+null.
-                    // Orchestrators can now detect this and switch to a live REPL instead of retrying.
-                    return Err(format!(
-                        "interactive_only: /plugins {action} requires a live session to reload the plugin runtime.\nStart `claw` and run `/plugins {action}` inside the REPL, or use `claw plugins {action}` as a direct CLI command."
-                    ).into());
-                }
-                _ => {}
+            if let Some(action @ ("install" | "uninstall" | "enable" | "disable" | "update")) =
+                action.as_deref()
+            {
+                // #777: use interactive_only: prefix + \n hint so #776's classify/split
+                // emits error_kind:interactive_only + non-null hint instead of unknown+null.
+                // Orchestrators can now detect this and switch to a live REPL instead of retrying.
+                return Err(format!(
+                    "interactive_only: /plugins {action} requires a live session to reload the plugin runtime.\nStart `claw` and run `/plugins {action}` inside the REPL, or use `claw plugins {action}` as a direct CLI command."
+                ).into());
             }
             let cwd = env::current_dir()?;
             let payload = plugins_command_payload_for(
@@ -7852,8 +7847,12 @@ impl LiveCli {
                     let max_compact_rounds = 4;
                     let preserve_schedule = [4, 2, 1, 0];
 
-                    for round in 0..max_compact_rounds {
-                        let preserve = preserve_schedule[round];
+                    for (round, preserve) in preserve_schedule
+                        .iter()
+                        .copied()
+                        .enumerate()
+                        .take(max_compact_rounds)
+                    {
                         println!(
                             "  Auto-compacting session (round {}/{}, preserving {} recent messages)...",
                             round + 1,
@@ -8611,8 +8610,8 @@ impl LiveCli {
         let cwd = env::current_dir()?;
         // #803: reject flag-shaped tokens in list filter for BOTH text and JSON modes.
         // Previously the guard was JSON-only (#793); text mode silently returned empty success.
-        if action.as_deref() == Some("list") {
-            if let Some(filter) = target.as_deref() {
+        if action == Some("list") {
+            if let Some(filter) = target {
                 if filter.starts_with('-') {
                     if matches!(output_format, CliOutputFormat::Json) {
                         // ROADMAP #817: this is a handled local inventory parse error.
@@ -10073,9 +10072,7 @@ fn sandbox_json_value(status: &runtime::SandboxStatus) -> serde_json::Value {
     //        (#731: "not supported on macOS" is a degraded state, not a hard error;
     //         filesystem_active:true means partial containment is working)
     // error = enabled but unsupported AND no filesystem sandbox either (nothing active)
-    let top_status = if !status.enabled {
-        "ok"
-    } else if status.active {
+    let top_status = if !status.enabled || status.active {
         "ok"
     } else if status.supported {
         "warn"
@@ -14008,39 +14005,37 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
             let content = message
                 .blocks
                 .iter()
-                .filter_map(|block| match block {
-                    ContentBlock::Text { text } => {
-                        Some(InputContentBlock::Text { text: text.clone() })
-                    }
+                .map(|block| match block {
+                    ContentBlock::Text { text } => InputContentBlock::Text { text: text.clone() },
                     ContentBlock::Thinking {
                         thinking,
                         signature,
                     } => {
                         // 保留 Thinking 块：OpenAI 兼容协议会把它转成 reasoning_content 字段
                         // 回传给 DeepSeek V4（避免 400 "reasoning_content must be passed back" 错误）
-                        Some(InputContentBlock::Thinking {
+                        InputContentBlock::Thinking {
                             thinking: thinking.clone(),
                             signature: signature.clone(),
-                        })
+                        }
                     }
-                    ContentBlock::ToolUse { id, name, input } => Some(InputContentBlock::ToolUse {
+                    ContentBlock::ToolUse { id, name, input } => InputContentBlock::ToolUse {
                         id: id.clone(),
                         name: name.clone(),
                         input: serde_json::from_str(input)
                             .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
-                    }),
+                    },
                     ContentBlock::ToolResult {
                         tool_use_id,
                         output,
                         is_error,
                         ..
-                    } => Some(InputContentBlock::ToolResult {
+                    } => InputContentBlock::ToolResult {
                         tool_use_id: tool_use_id.clone(),
                         content: vec![ToolResultContentBlock::Text {
                             text: output.clone(),
                         }],
                         is_error: *is_error,
-                    }),
+                    },
                 })
                 .collect::<Vec<_>>();
             (!content.is_empty()).then(|| InputMessage {

--- a/rust/crates/rusty-claude-cli/src/setup_wizard.rs
+++ b/rust/crates/rusty-claude-cli/src/setup_wizard.rs
@@ -2,8 +2,6 @@ use std::io::{self, IsTerminal, Write};
 
 use runtime::{save_user_provider_settings, ConfigLoader, RuntimeProviderConfig};
 
-use serde_json;
-
 const PROVIDERS: &[(&str, &str, &str)] = &[
     ("1", "Anthropic", "anthropic"),
     ("2", "xAI / Grok", "xai"),

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -1007,13 +1007,13 @@ fn inventory_commands_emit_structured_json_when_requested() {
     assert!(
         !plugins
             .as_object()
-            .map_or(false, |o| o.contains_key("reload_runtime")),
+            .is_some_and(|o| o.contains_key("reload_runtime")),
         "plugins list should not include reload_runtime"
     );
     assert!(
         !plugins
             .as_object()
-            .map_or(false, |o| o.contains_key("target")),
+            .is_some_and(|o| o.contains_key("target")),
         "plugins list should not include target"
     );
     // #703: structured summary replaces prose message
@@ -1706,13 +1706,13 @@ fn resumed_inventory_commands_emit_structured_json_when_requested() {
     assert!(
         !plugins
             .as_object()
-            .map_or(false, |o| o.contains_key("reload_runtime")),
+            .is_some_and(|o| o.contains_key("reload_runtime")),
         "plugins list should not include reload_runtime"
     );
     assert!(
         !plugins
             .as_object()
-            .map_or(false, |o| o.contains_key("target")),
+            .is_some_and(|o| o.contains_key("target")),
         "plugins list should not include target"
     );
     assert!(
@@ -2983,9 +2983,9 @@ fn flag_value_errors_have_error_kind_and_hint_756() {
         "invalid --reasoning-effort must be invalid_flag_value (#756): {parsed}"
     );
     assert!(
-        parsed["hint"].as_str().map_or(false, |h| h.contains("low")
-            || h.contains("medium")
-            || h.contains("high")),
+        parsed["hint"]
+            .as_str()
+            .is_some_and(|h| h.contains("low") || h.contains("medium") || h.contains("high")),
         "hint must mention valid values (#756): {parsed}"
     );
 
@@ -3011,7 +3011,7 @@ fn flag_value_errors_have_error_kind_and_hint_756() {
         "missing --model value must be missing_flag_value (#756): {parsed2}"
     );
     assert!(
-        parsed2["hint"].as_str().map_or(false, |h| !h.is_empty()),
+        parsed2["hint"].as_str().is_some_and(|h| !h.is_empty()),
         "missing --model hint must be non-empty (#756): {parsed2}"
     );
 }
@@ -3255,7 +3255,7 @@ fn short_p_flag_swallows_no_flags_755() {
         "flag-like token after -p must be rejected as missing_prompt (#755): {parsed2}"
     );
     assert!(
-        parsed2["hint"].as_str().map_or(false, |h| !h.is_empty()),
+        parsed2["hint"].as_str().is_some_and(|h| !h.is_empty()),
         "missing_prompt hint must be non-empty (#755)"
     );
 }
@@ -3397,7 +3397,7 @@ fn config_unsupported_section_json_hint_741() {
         assert!(
             parsed["supported_sections"]
                 .as_array()
-                .map_or(false, |a| !a.is_empty()),
+                .is_some_and(|a| !a.is_empty()),
             "config {section} JSON must include supported_sections (#741)"
         );
     }

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables, clippy::cmp_owned, clippy::unnecessary_map_or)]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};

--- a/scripts/generate_cc2_board.py
+++ b/scripts/generate_cc2_board.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -93,22 +94,27 @@ def slugify(text: str, limit: int = 54) -> str:
     return slug[:limit].strip("-") or "item"
 
 
-def find_source_omx(repo_root: Path) -> Path:
-    candidates = []
-    env = None
-    try:
-        import os
-        env = os.environ.get("CC2_SOURCE_OMX")
-    except Exception:
-        env = None
+def find_source_omx(repo_root: Path, env_value: str | None = None) -> Path:
+    candidates: list[Path] = []
+    env = env_value if env_value is not None else os.environ.get("CC2_SOURCE_OMX")
     if env:
         candidates.append(Path(env).expanduser())
     candidates.append(repo_root / ".omx")
     candidates.extend(parent / ".omx" for parent in repo_root.parents)
-    for candidate in candidates:
+
+    checked: list[Path] = []
+    for candidate in dict.fromkeys(candidate.resolve() for candidate in candidates):
+        checked.append(candidate)
         if (candidate / "plans" / "claw-code-2-0-adaptive-plan.md").exists() and (candidate / "research").exists():
             return candidate
-    raise FileNotFoundError("could not locate source .omx with plans/claw-code-2-0-adaptive-plan.md and research/")
+
+    searched = "\n".join(f"  - {path}" for path in checked)
+    raise FileNotFoundError(
+        "could not locate source .omx with plans/claw-code-2-0-adaptive-plan.md and research/\n"
+        f"searched:\n{searched}\n"
+        "Recovery: restore the frozen CC2 source bundle or Set CC2_SOURCE_OMX=/path/to/.omx. "
+        "The source root must contain plans/claw-code-2-0-adaptive-plan.md and research/."
+    )
 
 
 def parse_roadmap(path: Path) -> tuple[list[RoadmapRecord], list[RoadmapRecord]]:

--- a/scripts/generate_cc2_board.py
+++ b/scripts/generate_cc2_board.py
@@ -12,7 +12,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 REQUIRED_ITEM_FIELDS = [
     "id",
@@ -94,26 +94,42 @@ def slugify(text: str, limit: int = 54) -> str:
     return slug[:limit].strip("-") or "item"
 
 
-def find_source_omx(repo_root: Path, env_value: str | None = None) -> Path:
+def source_omx_candidates(repo_root: Path, env_value: str | None = None) -> list[Path]:
     candidates: list[Path] = []
     env = env_value if env_value is not None else os.environ.get("CC2_SOURCE_OMX")
     if env:
         candidates.append(Path(env).expanduser())
     candidates.append(repo_root / ".omx")
     candidates.extend(parent / ".omx" for parent in repo_root.parents)
+    return list(dict.fromkeys(candidate.resolve() for candidate in candidates))
 
+
+def format_source_omx_search(paths: list[Path]) -> str:
+    searched = "\n".join(f"  - {path}" for path in paths)
+    return (
+        f"searched:\n{searched}\n"
+        "Recovery: restore the frozen CC2 source bundle or Set CC2_SOURCE_OMX=/path/to/.omx. "
+        "The source root must contain plans/claw-code-2-0-adaptive-plan.md and research/."
+    )
+
+
+def find_source_omx(
+    repo_root: Path,
+    env_value: str | None = None,
+    warn: Callable[[str], None] | None = None,
+) -> Path:
     checked: list[Path] = []
-    for candidate in dict.fromkeys(candidate.resolve() for candidate in candidates):
+    for candidate in source_omx_candidates(repo_root, env_value):
         checked.append(candidate)
         if (candidate / "plans" / "claw-code-2-0-adaptive-plan.md").exists() and (candidate / "research").exists():
             return candidate
 
-    searched = "\n".join(f"  - {path}" for path in checked)
+    search_message = format_source_omx_search(checked)
+    if warn is not None:
+        warn(f"warning: searching for CC2 source .omx\n{search_message}")
     raise FileNotFoundError(
         "could not locate source .omx with plans/claw-code-2-0-adaptive-plan.md and research/\n"
-        f"searched:\n{searched}\n"
-        "Recovery: restore the frozen CC2 source bundle or Set CC2_SOURCE_OMX=/path/to/.omx. "
-        "The source root must contain plans/claw-code-2-0-adaptive-plan.md and research/."
+        f"{search_message}"
     )
 
 
@@ -425,9 +441,9 @@ def validate_board(board: dict[str, Any]) -> list[str]:
     return errors
 
 
-def build_board(repo_root: Path) -> dict[str, Any]:
+def build_board(repo_root: Path, warn: Callable[[str], None] | None = None) -> dict[str, Any]:
     roadmap_path = repo_root / "ROADMAP.md"
-    source_omx = find_source_omx(repo_root)
+    source_omx = find_source_omx(repo_root, warn=warn)
     research = source_omx / "research"
     plan_path = source_omx / "plans" / "claw-code-2-0-adaptive-plan.md"
     headings, actions = parse_roadmap(roadmap_path)
@@ -510,7 +526,7 @@ def main() -> int:
     repo_root = args.repo_root.resolve()
     out_dir = args.out_dir or (repo_root / ".omx" / "cc2")
     try:
-        board = build_board(repo_root)
+        board = build_board(repo_root, warn=lambda message: print(message, file=sys.stderr))
     except FileNotFoundError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/tests/test_cc2_board_generator.py
+++ b/tests/test_cc2_board_generator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = REPO_ROOT / "scripts" / "generate_cc2_board.py"
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location("generate_cc2_board", GENERATOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CC2BoardGeneratorTests(unittest.TestCase):
+    def test_missing_source_omx_error_lists_searched_paths_and_recovery_steps(self) -> None:
+        generator = load_generator()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir) / "repo"
+            repo_root.mkdir()
+            (repo_root / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+
+            with self.assertRaises(FileNotFoundError) as caught:
+                generator.find_source_omx(repo_root)
+
+        message = str(caught.exception)
+        self.assertIn("could not locate source .omx", message)
+        self.assertIn("searched:", message)
+        self.assertIn(str(repo_root / ".omx"), message)
+        self.assertIn("Set CC2_SOURCE_OMX", message)
+        self.assertIn("plans/claw-code-2-0-adaptive-plan.md", message)
+        self.assertIn("research/", message)
+
+    def test_source_omx_can_be_supplied_by_env(self) -> None:
+        generator = load_generator()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo_root = temp_root / "repo"
+            repo_root.mkdir()
+            source = temp_root / "cc2-source"
+            (source / "plans").mkdir(parents=True)
+            (source / "research").mkdir()
+            (source / "plans" / "claw-code-2-0-adaptive-plan.md").write_text(
+                "# approved plan\n", encoding="utf-8"
+            )
+
+            self.assertEqual(source, generator.find_source_omx(repo_root, env_value=str(source)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cc2_board_generator.py
+++ b/tests/test_cc2_board_generator.py
@@ -39,6 +39,23 @@ class CC2BoardGeneratorTests(unittest.TestCase):
         self.assertIn("plans/claw-code-2-0-adaptive-plan.md", message)
         self.assertIn("research/", message)
 
+    def test_missing_source_omx_emits_warning_before_failure(self) -> None:
+        generator = load_generator()
+        warnings: list[str] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir) / "repo"
+            repo_root.mkdir()
+
+            with self.assertRaises(FileNotFoundError):
+                generator.find_source_omx(repo_root, warn=warnings.append)
+
+        self.assertEqual(1, len(warnings))
+        warning = warnings[0]
+        self.assertIn("warning: searching for CC2 source .omx", warning)
+        self.assertIn("searched:", warning)
+        self.assertIn(str(repo_root / ".omx"), warning)
+        self.assertIn("Set CC2_SOURCE_OMX", warning)
+
     def test_source_omx_can_be_supplied_by_env(self) -> None:
         generator = load_generator()
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- improves CC2 board source-bundle discovery diagnostics
- lists searched .omx candidate paths when required artifacts are missing
- supports CC2_SOURCE_OMX for explicit source bundle selection
- keeps current workspace clippy gate green against current main

## Test Plan
- python3 -m unittest discover -s tests -v
- cd rust && ../scripts/fmt.sh --check
- cd rust && cargo clippy --workspace --all-targets -- -D warnings
- cd rust && cargo test --workspace

## Notes
The board generator still requires the frozen CC2 source bundle. This change makes the failure actionable instead of silently guessing or fabricating source artifacts.