### PR TITLE
feat(setup): separate env namespace for custom OpenAI-compat provider

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -364,10 +364,11 @@ Reasoning variants (`qwen-qwq-*`, `qwq-*`, `*-thinking`) automatically strip `te
 | **xAI** | OpenAI-compatible | `XAI_API_KEY` | `XAI_BASE_URL` | `https://api.x.ai/v1` |
 | **OpenAI-compatible** | OpenAI Chat Completions | `OPENAI_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
 | **DashScope** (Alibaba) | OpenAI-compatible | `DASHSCOPE_API_KEY` | `DASHSCOPE_BASE_URL` | `https://dashscope.aliyuncs.com/compatible-mode/v1` |
+| **Custom OpenAI-compat** | OpenAI Chat Completions | `CLAWCUSTOMOPENAI_API_KEY` | `CLAWCUSTOMOPENAI_BASE_URL` | none (must be supplied) |
 
 The OpenAI-compatible backend also serves as the gateway for **OpenRouter**, **Ollama**, and any other service that speaks the OpenAI `/v1/chat/completions` wire format — just point `OPENAI_BASE_URL` at the service.
 
-**Model-name prefix routing:** If a model name starts with `openai/`, `local/`, `gpt-`, `qwen/`, `qwen-`, `kimi/`, or `kimi-`, the provider is selected by the prefix regardless of which env vars are set. This prevents accidental misrouting to Anthropic when multiple credentials exist in the environment. For the default OpenAI API and local/private OpenAI-compatible endpoints, `openai/` is a routing prefix and is stripped before the request hits the wire. For non-local custom `OPENAI_BASE_URL` gateways, slash-containing OpenAI-compatible slugs (for example OpenRouter-style `openai/gpt-4.1-mini`) are preserved so the gateway receives the model ID it expects. The `local/` prefix is an explicit escape hatch for local slash-containing model IDs: it is stripped while the rest of the model ID is sent verbatim.
+**Model-name prefix routing:** If a model name starts with `openai/`, `local/`, `custom/`, `gpt-`, `qwen/`, `qwen-`, `kimi/`, or `kimi-`, the provider is selected by the prefix regardless of which env vars are set. This prevents accidental misrouting to Anthropic when multiple credentials exist in the environment. For the default OpenAI API and local/private OpenAI-compatible endpoints, `openai/` is a routing prefix and is stripped before the request hits the wire. For non-local custom `OPENAI_BASE_URL` gateways, slash-containing OpenAI-compatible slugs (for example OpenRouter-style `openai/gpt-4.1-mini`) are preserved so the gateway receives the model ID it expects. The `local/` prefix is an explicit escape hatch for local slash-containing model IDs: it is stripped while the rest of the model ID is sent verbatim. The `custom/` prefix selects the Claw-specific custom OpenAI-compat provider (`CLAWCUSTOMOPENAI_*` env vars) and is also stripped on the wire; use it when you want a private OpenAI-compatible endpoint that does not collide with real `OPENAI_*` credentials.
 
 ### Tested models and aliases
 
@@ -407,15 +408,22 @@ Local project settings override user-level settings. Aliases resolve through the
 
 Model selection precedence is CLI flag, environment, config, then default. The environment model slot accepts `CLAW_MODEL`, `ANTHROPIC_MODEL`, and `ANTHROPIC_DEFAULT_MODEL` in that order; aliases from those variables are resolved and validated before provider startup. `claw --output-format json status` exposes `model_raw`, `model_alias_resolved_to`, and `model_env_var` so automation can see the winning value.
 
+### /setup wizard
+
+Run `/setup` inside the REPL (or `claw setup` from the shell) to save provider credentials interactively to `~/.claw/settings.json`. Saved settings are injected as env-var fallbacks at startup, preserving the precedence: env var > `.env` file > stored config.
+
+For a **Custom (OpenAI-compat)** endpoint, `/setup` now stores `kind: "custom-openai"` and sets the dedicated `CLAWCUSTOMOPENAI_API_KEY` / `CLAWCUSTOMOPENAI_BASE_URL` env vars. This lets a private OpenAI-compatible proxy coexist with real OpenAI, NeuralWatt, or other tools that already consume `OPENAI_*`. A bare model name saved by `/setup` is normalized to `custom/<model>` and stripped back to the bare id on the wire.
+
 ### How provider detection works
 
 1. If the resolved model name starts with `claude` → Anthropic.
 2. If it starts with `grok` → xAI.
-3. If it starts with `openai/`, `local/`, or `gpt-` → OpenAI-compatible.
+3. If it starts with `openai/`, `local/`, `custom/`, or `gpt-` → OpenAI-compatible.
 4. If it starts with `qwen/`, `qwen-`, `kimi/`, or `kimi-` → DashScope-compatible OpenAI wire format.
 5. If `OPENAI_BASE_URL` is set, local-looking unknown model names such as `llama3.2` or `qwen2.5-coder:7b` route to the OpenAI-compatible client for local/gateway servers.
-6. Otherwise, `claw` checks which credential is set: Anthropic first, then OpenAI, then xAI. If only `OPENAI_BASE_URL` is set, it still routes to OpenAI-compatible for authless local servers.
-7. If nothing matches, it defaults to Anthropic.
+6. If it starts with `custom/` → the Claw custom OpenAI-compat provider (`CLAWCUSTOMOPENAI_API_KEY` / `CLAWCUSTOMOPENAI_BASE_URL`).
+7. Otherwise, `claw` checks which credential is set: Anthropic first, then OpenAI, then xAI. If only `OPENAI_BASE_URL` is set, it still routes to OpenAI-compatible for authless local servers.
+8. If nothing matches, it defaults to Anthropic.
 
 
 ### Provider diagnostics and custom OpenAI-compatible parameters

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -47,6 +47,9 @@ impl ProviderClient {
                         Some(meta) if meta.auth_env == "DASHSCOPE_API_KEY" => {
                             OpenAiCompatConfig::dashscope()
                         }
+                        Some(meta) if meta.auth_env == "CLAWCUSTOMOPENAI_API_KEY" => {
+                            OpenAiCompatConfig::custom_openai()
+                        }
                         _ => OpenAiCompatConfig::openai(),
                     };
                     Ok(Self::OpenAi(OpenAiCompatClient::from_env(config)?))

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -270,6 +270,14 @@ pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
             default_base_url: openai_compat::DEFAULT_OPENAI_BASE_URL,
         });
     }
+    if canonical.starts_with("custom/") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::OpenAi,
+            auth_env: "CLAWCUSTOMOPENAI_API_KEY",
+            base_url_env: "CLAWCUSTOMOPENAI_BASE_URL",
+            default_base_url: openai_compat::DEFAULT_CUSTOM_OPENAI_BASE_URL,
+        });
+    }
     // Alibaba DashScope compatible-mode endpoint. Routes qwen/* and bare
     // qwen-* model names (qwen-max, qwen-plus, qwen-turbo, qwen-qwq, etc.)
     // to the OpenAI-compat client pointed at DashScope's /compatible-mode/v1.
@@ -375,6 +383,11 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     if std::env::var_os("OPENAI_BASE_URL").is_some()
         && looks_like_local_openai_model(&resolved_model)
     {
+        return ProviderKind::OpenAi;
+    }
+    // Explicit `custom/` prefix selects the Claw custom OpenAI-compat provider
+    // even when no other credentials are present.
+    if resolved_model.starts_with("custom/") {
         return ProviderKind::OpenAi;
     }
     if anthropic::has_auth_from_env_or_saved().unwrap_or(false) {
@@ -1136,6 +1149,21 @@ mod tests {
     fn kimi_alias_resolves_to_kimi_k2_5() {
         assert_eq!(super::resolve_model_alias("kimi"), "kimi-k2.5");
         assert_eq!(super::resolve_model_alias("KIMI"), "kimi-k2.5"); // case insensitive
+    }
+
+    #[test]
+    fn custom_prefix_routes_to_custom_openai_env_vars() {
+        let meta = super::metadata_for_model("custom/openclaw_3750")
+            .expect("custom/ prefix must resolve to custom OpenAI metadata");
+        assert_eq!(meta.provider, ProviderKind::OpenAi);
+        assert_eq!(meta.auth_env, "CLAWCUSTOMOPENAI_API_KEY");
+        assert_eq!(meta.base_url_env, "CLAWCUSTOMOPENAI_BASE_URL");
+
+        assert_eq!(
+            detect_provider_kind("custom/openclaw_3750"),
+            ProviderKind::OpenAi,
+            "custom/ prefix must select OpenAi provider kind"
+        );
     }
 
     #[test]

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -21,6 +21,11 @@ use super::{preflight_message_request, resolve_model_alias, Provider, ProviderFu
 pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
 pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEFAULT_DASHSCOPE_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+/// Default base URL for Claw's custom OpenAI-compatible provider.
+/// Intentionally left empty: a custom endpoint must set
+/// `CLAWCUSTOMOPENAI_BASE_URL`; otherwise requests will fail at URL build
+/// time rather than leaking credentials to the real OpenAI endpoint.
+pub const DEFAULT_CUSTOM_OPENAI_BASE_URL: &str = "";
 const REQUEST_ID_HEADER: &str = "request-id";
 const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
 const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
@@ -43,6 +48,7 @@ pub struct OpenAiCompatConfig {
 const XAI_ENV_VARS: &[&str] = &["XAI_API_KEY"];
 const OPENAI_ENV_VARS: &[&str] = &["OPENAI_API_KEY"];
 const DASHSCOPE_ENV_VARS: &[&str] = &["DASHSCOPE_API_KEY"];
+const CUSTOM_OPENAI_ENV_VARS: &[&str] = &["CLAWCUSTOMOPENAI_API_KEY"];
 
 // Provider-specific request body size limits in bytes
 const XAI_MAX_REQUEST_BODY_BYTES: usize = 52_428_800; // 50MB
@@ -95,12 +101,27 @@ impl OpenAiCompatConfig {
         }
     }
 
+    /// Claw-specific custom OpenAI-compatible endpoint.
+    /// Reads `CLAWCUSTOMOPENAI_API_KEY` / `CLAWCUSTOMOPENAI_BASE_URL` so it
+    /// can coexist with real OpenAI/NeuralWatt `OPENAI_*` environment vars.
+    #[must_use]
+    pub const fn custom_openai() -> Self {
+        Self {
+            provider_name: "Custom OpenAI",
+            api_key_env: "CLAWCUSTOMOPENAI_API_KEY",
+            base_url_env: "CLAWCUSTOMOPENAI_BASE_URL",
+            default_base_url: DEFAULT_CUSTOM_OPENAI_BASE_URL,
+            max_request_body_bytes: OPENAI_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+
     #[must_use]
     pub fn credential_env_vars(self) -> &'static [&'static str] {
         match self.provider_name {
             "xAI" => XAI_ENV_VARS,
             "OpenAI" => OPENAI_ENV_VARS,
             "DashScope" => DASHSCOPE_ENV_VARS,
+            "Custom OpenAI" => CUSTOM_OPENAI_ENV_VARS,
             _ => &[],
         }
     }
@@ -1066,7 +1087,7 @@ fn wire_model_for_base_url<'a>(
     if matches!(lowered_prefix.as_str(), "xai" | "grok" | "qwen" | "kimi") {
         return Cow::Borrowed(&model[pos + 1..]);
     }
-    if lowered_prefix == "local" {
+    if matches!(lowered_prefix.as_str(), "local" | "custom") {
         return Cow::Borrowed(&model[pos + 1..]);
     }
 
@@ -2276,6 +2297,29 @@ mod tests {
             json!({"city": "Paris"})
         );
         assert_eq!(parse_tool_arguments("not-json"), json!({"raw": "not-json"}));
+    }
+
+    #[test]
+    fn custom_routing_prefix_strips_on_wire() {
+        let payload = build_chat_completion_request(
+            &MessageRequest {
+                model: "custom/openclaw_3750".to_string(),
+                max_tokens: 64,
+                messages: vec![InputMessage::user_text("hello")],
+                ..Default::default()
+            },
+            OpenAiCompatConfig::custom_openai(),
+        );
+
+        assert_eq!(payload["model"], json!("openclaw_3750"));
+    }
+
+    #[test]
+    fn custom_openai_config_uses_separate_env_vars() {
+        let config = OpenAiCompatConfig::custom_openai();
+        assert_eq!(config.provider_name, "Custom OpenAI");
+        assert_eq!(config.api_key_env, "CLAWCUSTOMOPENAI_API_KEY");
+        assert_eq!(config.base_url_env, "CLAWCUSTOMOPENAI_BASE_URL");
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3124,26 +3124,21 @@ fn config_model_for_current_dir() -> Option<String> {
     let model = config.model()?;
 
     // If the user configured a custom OpenAI-compatible endpoint with a bare
-    // model name (e.g. "openclaw"), normalize it to "openai/openclaw" so it
-    // passes provider/model syntax validation. Real OpenAI bare names like
-    // "gpt-4" are already accepted as aliases.
-    if config_has_custom_openai_base_url(&config) && !model.contains('/') {
-        return Some(format!("openai/{model}"));
+    // model name (e.g. "openclaw"), route it through the custom/ prefix so it
+    // passes validation, maps to the custom OpenAI-compat client, and gets
+    // stripped down to the bare model id on the wire (avoiding a proxy 404).
+    if is_custom_openai_provider(&config) && !model.contains('/') {
+        return Some(format!("custom/{model}"));
     }
 
     Some(model.to_owned())
 }
 
-/// Check whether the loaded config has a custom OpenAI-compatible base URL.
-fn config_has_custom_openai_base_url(config: &runtime::RuntimeConfig) -> bool {
-    let provider = config.provider();
-    if provider.kind() != Some("openai") && provider.kind() != Some("openai-compat") {
-        return false;
-    }
-    let Some(base_url) = provider.base_url() else {
-        return false;
-    };
-    !base_url.is_empty() && base_url != "https://api.openai.com/v1"
+/// Check whether the loaded config uses the Claw custom OpenAI-compatible
+/// provider, which has its own env var namespace so it can coexist with real
+/// OpenAI/NeuralWatt credentials.
+fn is_custom_openai_provider(config: &runtime::RuntimeConfig) -> bool {
+    config.provider().kind() == Some("custom-openai")
 }
 
 fn resolve_repl_model(cli_model: String) -> Result<String, String> {
@@ -12677,6 +12672,7 @@ fn inject_config_as_env_fallbacks() {
         "xai" => ("XAI_API_KEY", "XAI_BASE_URL"),
         "openai" => ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
         "dashscope" => ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
+        "custom-openai" => ("CLAWCUSTOMOPENAI_API_KEY", "CLAWCUSTOMOPENAI_BASE_URL"),
         _ => return, // unknown provider kind — don't inject
     };
 
@@ -14713,6 +14709,178 @@ mod tests {
                 allow_broad_cwd: false,
             }
         );
+    }
+
+    #[test]
+    fn config_model_normalizes_bare_name_to_custom_prefix_for_custom_openai_provider() {
+        let _guard = env_lock();
+        let root = temp_dir();
+        let cwd = root.join("project");
+        let config_home = root.join("config-home");
+        std::fs::create_dir_all(&cwd).expect("project dir should exist");
+        std::fs::create_dir_all(&config_home).expect("config home should exist");
+        std::fs::write(
+            config_home.join("settings.json"),
+            r#"{
+                "provider": {
+                    "kind": "custom-openai",
+                    "apiKey": "sk-test",
+                    "baseUrl": "http://localhost:9999/v1"
+                },
+                "model": "openclaw"
+            }"#,
+        )
+        .expect("user settings should write");
+
+        let original_config_home = std::env::var("CLAW_CONFIG_HOME").ok();
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+
+        let resolved = with_current_dir(&cwd, super::config_model_for_current_dir);
+
+        match original_config_home {
+            Some(value) => std::env::set_var("CLAW_CONFIG_HOME", value),
+            None => std::env::remove_var("CLAW_CONFIG_HOME"),
+        }
+        std::fs::remove_dir_all(root).expect("temp config root should clean up");
+
+        assert_eq!(resolved, Some("custom/openclaw".to_string()));
+    }
+
+    #[test]
+    fn config_model_leaves_openai_kind_bare_model_unnormalized() {
+        let _guard = env_lock();
+        let root = temp_dir();
+        let cwd = root.join("project");
+        let config_home = root.join("config-home");
+        std::fs::create_dir_all(&cwd).expect("project dir should exist");
+        std::fs::create_dir_all(&config_home).expect("config home should exist");
+        std::fs::write(
+            config_home.join("settings.json"),
+            r#"{
+                "provider": {
+                    "kind": "openai",
+                    "apiKey": "sk-test",
+                    "baseUrl": "http://localhost:9999/v1"
+                },
+                "model": "openclaw"
+            }"#,
+        )
+        .expect("user settings should write");
+
+        let original_config_home = std::env::var("CLAW_CONFIG_HOME").ok();
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+
+        let resolved = with_current_dir(&cwd, super::config_model_for_current_dir);
+
+        match original_config_home {
+            Some(value) => std::env::set_var("CLAW_CONFIG_HOME", value),
+            None => std::env::remove_var("CLAW_CONFIG_HOME"),
+        }
+        std::fs::remove_dir_all(root).expect("temp config root should clean up");
+
+        assert_eq!(resolved, Some("openclaw".to_string()));
+    }
+
+    #[test]
+    fn inject_config_as_env_fallbacks_sets_openai_provider_env_vars() {
+        let _guard = env_lock();
+        let root = temp_dir();
+        let cwd = root.join("project");
+        let config_home = root.join("config-home");
+        std::fs::create_dir_all(&cwd).expect("project dir should exist");
+        std::fs::create_dir_all(&config_home).expect("config home should exist");
+        std::fs::write(
+            config_home.join("settings.json"),
+            r#"{
+                "provider": {
+                    "kind": "openai",
+                    "apiKey": "sk-from-config",
+                    "baseUrl": "http://localhost:9999/v1"
+                }
+            }"#,
+        )
+        .expect("user settings should write");
+
+        let original_config_home = std::env::var("CLAW_CONFIG_HOME").ok();
+        let original_api_key = std::env::var("OPENAI_API_KEY").ok();
+        let original_base_url = std::env::var("OPENAI_BASE_URL").ok();
+
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("OPENAI_BASE_URL");
+
+        with_current_dir(&cwd, super::inject_config_as_env_fallbacks);
+
+        let api_key = std::env::var("OPENAI_API_KEY").ok();
+        let base_url = std::env::var("OPENAI_BASE_URL").ok();
+
+        match original_config_home {
+            Some(value) => std::env::set_var("CLAW_CONFIG_HOME", value),
+            None => std::env::remove_var("CLAW_CONFIG_HOME"),
+        }
+        match original_api_key {
+            Some(value) => std::env::set_var("OPENAI_API_KEY", value),
+            None => std::env::remove_var("OPENAI_API_KEY"),
+        }
+        match original_base_url {
+            Some(value) => std::env::set_var("OPENAI_BASE_URL", value),
+            None => std::env::remove_var("OPENAI_BASE_URL"),
+        }
+        std::fs::remove_dir_all(root).expect("temp config root should clean up");
+
+        assert_eq!(api_key, Some("sk-from-config".to_string()));
+        assert_eq!(base_url, Some("http://localhost:9999/v1".to_string()));
+    }
+
+    #[test]
+    fn inject_config_as_env_fallbacks_sets_custom_openai_provider_env_vars() {
+        let _guard = env_lock();
+        let root = temp_dir();
+        let cwd = root.join("project");
+        let config_home = root.join("config-home");
+        std::fs::create_dir_all(&cwd).expect("project dir should exist");
+        std::fs::create_dir_all(&config_home).expect("config home should exist");
+        std::fs::write(
+            config_home.join("settings.json"),
+            r#"{
+                "provider": {
+                    "kind": "custom-openai",
+                    "apiKey": "sk-from-config",
+                    "baseUrl": "http://localhost:9999/v1"
+                }
+            }"#,
+        )
+        .expect("user settings should write");
+
+        let original_config_home = std::env::var("CLAW_CONFIG_HOME").ok();
+        let original_api_key = std::env::var("CLAWCUSTOMOPENAI_API_KEY").ok();
+        let original_base_url = std::env::var("CLAWCUSTOMOPENAI_BASE_URL").ok();
+
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+        std::env::remove_var("CLAWCUSTOMOPENAI_API_KEY");
+        std::env::remove_var("CLAWCUSTOMOPENAI_BASE_URL");
+
+        with_current_dir(&cwd, super::inject_config_as_env_fallbacks);
+
+        let api_key = std::env::var("CLAWCUSTOMOPENAI_API_KEY").ok();
+        let base_url = std::env::var("CLAWCUSTOMOPENAI_BASE_URL").ok();
+
+        match original_config_home {
+            Some(value) => std::env::set_var("CLAW_CONFIG_HOME", value),
+            None => std::env::remove_var("CLAW_CONFIG_HOME"),
+        }
+        match original_api_key {
+            Some(value) => std::env::set_var("CLAWCUSTOMOPENAI_API_KEY", value),
+            None => std::env::remove_var("CLAWCUSTOMOPENAI_API_KEY"),
+        }
+        match original_base_url {
+            Some(value) => std::env::set_var("CLAWCUSTOMOPENAI_BASE_URL", value),
+            None => std::env::remove_var("CLAWCUSTOMOPENAI_BASE_URL"),
+        }
+        std::fs::remove_dir_all(root).expect("temp config root should clean up");
+
+        assert_eq!(api_key, Some("sk-from-config".to_string()));
+        assert_eq!(base_url, Some("http://localhost:9999/v1".to_string()));
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -12554,6 +12554,12 @@ impl AnthropicRuntimeClient {
         tool_registry: GlobalToolRegistry,
         progress_reporter: Option<InternalPromptProgressReporter>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Inject saved provider settings (from /setup wizard) as env var
+        // fallbacks. The API client constructors read env vars only,
+        // so we set them here when the user hasn't already set them.
+        // 3-tier resolution: env var > .env file > stored config.
+        inject_config_as_env_fallbacks();
+
         // Dispatch to the correct provider at construction time.
         // `ApiProviderClient` (exposed by the api crate as
         // `ProviderClient`) is an enum over Anthropic / xAI / OpenAI
@@ -12622,6 +12628,44 @@ fn resolve_cli_auth_source() -> Result<AuthSource, Box<dyn std::error::Error>> {
 #[allow(clippy::result_large_err)]
 fn resolve_cli_auth_source_for_cwd() -> Result<AuthSource, api::ApiError> {
     resolve_startup_auth_source(|| Ok(None))
+}
+
+/// Inject provider settings from `~/.claw/settings.json` as environment
+/// variable fallbacks so the API client constructors (which only read env
+/// vars) can find them.
+///
+/// This bridges the gap between `/setup` (which saves apiKey/baseUrl to
+/// the config file) and the API crate (which reads env vars only).
+/// Already-set env vars are never overwritten — the 3-tier resolution
+/// order is preserved: env var > .env file > stored config.
+fn inject_config_as_env_fallbacks() {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let Ok(config) = runtime::ConfigLoader::default_for(&cwd).load() else {
+        return;
+    };
+    let provider = config.provider();
+
+    // Map provider kind to the expected env var names
+    let (api_key_env, base_url_env) = match provider.kind().unwrap_or("anthropic") {
+        "anthropic" => ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"),
+        "xai" => ("XAI_API_KEY", "XAI_BASE_URL"),
+        "openai" => ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+        "dashscope" => ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
+        _ => return, // unknown provider kind — don't inject
+    };
+
+    // Only set env vars that aren't already set (preserve user's explicit env)
+    if let Some(api_key) = provider.api_key() {
+        if !api_key.is_empty() && std::env::var(api_key_env).is_err() {
+            std::env::set_var(api_key_env, api_key);
+        }
+    }
+
+    if let Some(base_url) = provider.base_url() {
+        if !base_url.is_empty() && std::env::var(base_url_env).is_err() {
+            std::env::set_var(base_url_env, base_url);
+        }
+    }
 }
 
 impl ApiClient for AnthropicRuntimeClient {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1003,6 +1003,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     let (args, cwd) = split_global_cwd_args(&args)?;
     apply_global_cwd(cwd)?;
+    // Inject saved provider settings (from /setup wizard) as env var fallbacks.
+    // The API client constructors read env vars only, so we set them once at
+    // process startup before any runtime threads are spawned. Already-set env
+    // vars are preserved — resolution order remains: env var > .env file >
+    // stored config. This only runs in the real binary (run() is not called by
+    // unit tests) to avoid leaking user config into the test suite.
+    inject_config_as_env_fallbacks();
     match parse_args(&args)? {
         CliAction::DumpManifests {
             output_format,
@@ -2986,6 +2993,8 @@ fn is_local_openai_model_syntax(model: &str) -> bool {
     if let Some(rest) = model.strip_prefix("local/") {
         return !rest.is_empty() && rest.split('/').all(|segment| !segment.is_empty());
     }
+    // Ollama-style tags (contain ':' or '.') are accepted when a custom
+    // OpenAI-compatible base URL is configured via OPENAI_BASE_URL.
     std::env::var_os("OPENAI_BASE_URL").is_some() && (model.contains(':') || model.contains('.'))
 }
 
@@ -3111,7 +3120,30 @@ fn config_permission_mode_for_current_dir() -> Option<PermissionMode> {
 fn config_model_for_current_dir() -> Option<String> {
     let cwd = env::current_dir().ok()?;
     let loader = ConfigLoader::default_for(&cwd);
-    loader.load().ok()?.model().map(ToOwned::to_owned)
+    let config = loader.load().ok()?;
+    let model = config.model()?;
+
+    // If the user configured a custom OpenAI-compatible endpoint with a bare
+    // model name (e.g. "openclaw"), normalize it to "openai/openclaw" so it
+    // passes provider/model syntax validation. Real OpenAI bare names like
+    // "gpt-4" are already accepted as aliases.
+    if config_has_custom_openai_base_url(&config) && !model.contains('/') {
+        return Some(format!("openai/{model}"));
+    }
+
+    Some(model.to_owned())
+}
+
+/// Check whether the loaded config has a custom OpenAI-compatible base URL.
+fn config_has_custom_openai_base_url(config: &runtime::RuntimeConfig) -> bool {
+    let provider = config.provider();
+    if provider.kind() != Some("openai") && provider.kind() != Some("openai-compat") {
+        return false;
+    }
+    let Some(base_url) = provider.base_url() else {
+        return false;
+    };
+    !base_url.is_empty() && base_url != "https://api.openai.com/v1"
 }
 
 fn resolve_repl_model(cli_model: String) -> Result<String, String> {
@@ -12554,12 +12586,6 @@ impl AnthropicRuntimeClient {
         tool_registry: GlobalToolRegistry,
         progress_reporter: Option<InternalPromptProgressReporter>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Inject saved provider settings (from /setup wizard) as env var
-        // fallbacks. The API client constructors read env vars only,
-        // so we set them here when the user hasn't already set them.
-        // 3-tier resolution: env var > .env file > stored config.
-        inject_config_as_env_fallbacks();
-
         // Dispatch to the correct provider at construction time.
         // `ApiProviderClient` (exposed by the api crate as
         // `ProviderClient`) is an enum over Anthropic / xAI / OpenAI

--- a/rust/crates/rusty-claude-cli/src/setup_wizard.rs
+++ b/rust/crates/rusty-claude-cli/src/setup_wizard.rs
@@ -9,7 +9,7 @@ const PROVIDERS: &[(&str, &str, &str)] = &[
     ("2", "xAI / Grok", "xai"),
     ("3", "OpenAI", "openai"),
     ("4", "DashScope (Qwen/Kimi)", "dashscope"),
-    ("5", "Custom (OpenAI-compat)", "openai"),
+    ("5", "Custom (OpenAI-compat)", "custom-openai"),
 ];
 
 const PROVIDER_MODELS: &[(&str, &[&str])] = &[
@@ -27,6 +27,8 @@ const DEFAULT_BASE_URLS: &[(&str, &str)] = &[
         "dashscope",
         "https://dashscope.aliyuncs.com/compatible-mode/v1",
     ),
+    // Custom OpenAI has no default base URL; the user must supply one.
+    ("custom-openai", ""),
 ];
 
 const API_KEY_ENV_VARS: &[(&str, &str)] = &[
@@ -34,6 +36,7 @@ const API_KEY_ENV_VARS: &[(&str, &str)] = &[
     ("xai", "XAI_API_KEY"),
     ("openai", "OPENAI_API_KEY"),
     ("dashscope", "DASHSCOPE_API_KEY"),
+    ("custom-openai", "CLAWCUSTOMOPENAI_API_KEY"),
 ];
 
 pub fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
@@ -177,6 +180,7 @@ fn prompt_base_url(
         "xai" => "XAI_BASE_URL",
         "openai" => "OPENAI_BASE_URL",
         "dashscope" => "DASHSCOPE_BASE_URL",
+        "custom-openai" => "CLAWCUSTOMOPENAI_BASE_URL",
         _ => "BASE_URL",
     };
     let env_set = std::env::var(env_var).ok().is_some_and(|v| !v.is_empty());
@@ -214,7 +218,11 @@ fn prompt_model(
     if !aliases.is_empty() {
         println!("    Common: {}", aliases.join(", "));
     }
-    println!("    Or enter any model name (e.g. openai/gpt-4.1-mini for custom routing)");
+    if kind == "custom-openai" {
+        println!("    Or enter any model name (e.g. custom/gpt-4.1 for custom routing)");
+    } else {
+        println!("    Or enter any model name (e.g. openai/gpt-4.1-mini for custom routing)");
+    }
 
     let input = read_line(&format!("  Model [{current_model}]: "))?;
     if input.trim().is_empty() {


### PR DESCRIPTION
## Problem

The `/setup` wizard's "Custom (OpenAI-compat)" option saved `kind: "openai"` and injected `OPENAI_API_KEY` / `OPENAI_BASE_URL`. That collides with users who already have real OpenAI, NeuralWatt, or other platform credentials in their environment, so the saved custom proxy URL was ignored and requests were misrouted.

## Changes

### New provider kind: `custom-openai`
- Uses dedicated env vars:
  - `CLAWCUSTOMOPENAI_API_KEY`
  - `CLAWCUSTOMOPENAI_BASE_URL`
- New model routing prefix `custom/` selects the OpenAI-compatible client with those env vars and is stripped on the wire, so the proxy receives the bare model id.

### `/setup` wizard updated
- Option 5 now saves `kind: "custom-openai"`.
- Prompts for `CLAWCUSTOMOPENAI_API_KEY` / `CLAWCUSTOMOPENAI_BASE_URL`.
- Bare model names saved by `/setup` are normalized to `custom/<model>`.

### Saved settings are applied at startup
- `inject_config_as_env_fallbacks()` is called once in `run()` before any runtime threads are spawned.
- Preserves 3-tier precedence: env var > `.env` file > stored config.

### API routing
- `metadata_for_model` and `detect_provider_kind` recognize `custom/`.
- `OpenAiCompatConfig::custom_openai()` reads the new env vars.
- `wire_model_for_base_url` strips `custom/` prefix.

### Tests
- `custom/` prefix routes to `CLAWCUSTOMOPENAI_*` env vars.
- `custom/` is stripped on the wire.
- `inject_config_as_env_fallbacks` sets both standard and custom env vars.
- Bare custom-openai model names normalize to `custom/`.

### Docs
- Updated `USAGE.md` provider matrix and prefix-routing section.
- Added `/setup` wizard section explaining the custom provider.

## Verification

- `cargo test -p api` passes.
- `cargo test -p rusty-claude-cli --bin claw config_model` passes.
- `cargo test -p rusty-claude-cli --bin claw inject_config` passes.
- Manual one-shot prompt against `http://100.96.49.42:4001/v1` with model `openclaw_3750` succeeded.

## Notes

- This PR intentionally **does not include the TUI work**; it targets `upstream/main` where the TUI changes are not present.
- Existing users who previously saved `kind: "openai"` with a custom base URL can re-run `/setup` to migrate to the new namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
