### PR TITLE
docs(rust/README): document xAI and Kimi model aliases

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -110,13 +110,27 @@ Primary artifacts:
 
 ## Model Aliases
 
-Short names resolve to the latest model versions:
+Short model aliases resolve to canonical model IDs. Because the router selects a
+provider from the resolved model, an alias also determines which backend and
+credentials are used — choose the alias for the provider you have an API key for.
+Alias resolution is case-insensitive (`OPUS` behaves the same as `opus`).
 
-| Alias | Resolves To |
-|-------|------------|
-| `opus` | `claude-opus-4-7` |
-| `sonnet` | `claude-sonnet-4-6` |
-| `haiku` | `claude-haiku-4-5-20251213` |
+| Alias | Resolves To | Provider | Auth env var |
+|-------|-------------|----------|--------------|
+| `opus` | `claude-opus-4-7` | Anthropic | `ANTHROPIC_API_KEY` |
+| `sonnet` | `claude-sonnet-4-6` | Anthropic | `ANTHROPIC_API_KEY` |
+| `haiku` | `claude-haiku-4-5-20251213` | Anthropic | `ANTHROPIC_API_KEY` |
+| `grok`, `grok-3` | `grok-3` | xAI | `XAI_API_KEY` |
+| `grok-mini`, `grok-3-mini` | `grok-3-mini` | xAI | `XAI_API_KEY` |
+| `grok-2` | `grok-2` | xAI | `XAI_API_KEY` |
+| `kimi` | `kimi-k2.5` | DashScope (OpenAI-compatible) | `DASHSCOPE_API_KEY` |
+
+Anthropic aliases track the latest published model versions. xAI models honor
+`XAI_BASE_URL` and Kimi honors `DASHSCOPE_BASE_URL` for base-URL overrides. Alias
+resolution is implemented in `resolve_model_alias`
+([`crates/api/src/providers/mod.rs`](./crates/api/src/providers/mod.rs)); for
+provider-specific request handling see
+[`../docs/MODEL_COMPATIBILITY.md`](../docs/MODEL_COMPATIBILITY.md).
 
 ## CLI Flags and Commands
 


### PR DESCRIPTION
## What

The **Model Aliases** table in `rust/README.md` only listed the three Anthropic
aliases (`opus`, `sonnet`, `haiku`), but `resolve_model_alias` in
`rust/crates/api/src/providers/mod.rs` also resolves xAI and Kimi aliases. This
PR documents the full alias set, adds a **Provider** and **Auth env var** column
so each alias is actionable, and notes that resolution is case-insensitive.

Newly documented aliases (verified against `MODEL_REGISTRY` / `resolve_model_alias`):

| Alias | Resolves To | Provider | Auth env var |
|-------|-------------|----------|--------------|
| `grok`, `grok-3` | `grok-3` | xAI | `XAI_API_KEY` |
| `grok-mini`, `grok-3-mini` | `grok-3-mini` | xAI | `XAI_API_KEY` |
| `grok-2` | `grok-2` | xAI | `XAI_API_KEY` |
| `kimi` | `kimi-k2.5` | DashScope (OpenAI-compatible) | `DASHSCOPE_API_KEY` |

## Why it's correct

Everything added is verifiable in the source, not invented:

- `resolve_model_alias()` maps `grok`/`grok-3` → `grok-3`, `grok-mini`/`grok-3-mini`
  → `grok-3-mini`, `grok-2` → `grok-2`, and `kimi` → `kimi-k2.5`.
- `MODEL_REGISTRY` sets the auth/base-url env vars for each provider:
  xAI → `XAI_API_KEY` / `XAI_BASE_URL`, Kimi → `DASHSCOPE_API_KEY` /
  `DASHSCOPE_BASE_URL`.
- Case-insensitivity: `resolve_model_alias` lowercases input before matching, and
  existing tests assert this (`kimi_alias_resolves_to_kimi_k2_5` checks `"KIMI"`,
  `resolves_grok_aliases` checks the grok family).
- Provider diagnostics already point users at these aliases (e.g. the hint to
  "use an xAI model alias such as `--model grok`"), and `docs/MODEL_COMPATIBILITY.md`
  documents the corresponding request handling — this PR just surfaces the aliases
  where they are listed.

## Scope

Docs-only change to `rust/README.md`. No code or behavior changes. The existing
`opus`/`sonnet`/`haiku` rows are unchanged.